### PR TITLE
Changed the logging information to say tables instead of dataset as r…

### DIFF
--- a/prism/prism.py
+++ b/prism/prism.py
@@ -349,7 +349,7 @@ class Prism:
         r.raise_for_status()
 
         if r.status_code == 200:
-            logging.info("Successfully obtained information about your datasets")
+            logging.info("Successfully obtained information about your tables")
             return r.json()
         else:
             logging.warning(f"HTTP status code {r.status_code}: {r.content}")


### PR DESCRIPTION
This PR changes the logging information in the describe_table function to be: 

`logging.info("Successfully obtained information about your tables")`

instead of what it was previously: 

`logging.info("Successfully obtained information about your datasets")`

This PR is in response to issue #25 