### PR TITLE
Fix logic bugs across prism.py and CLI command modules

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,10 +22,6 @@ jobs:
         pip install -r requirements.txt
     - name: Build source distribution
       run: python setup.py sdist
-    - name: Format with Black
-      run: |
-        pip install black
-        black . --check --verbose --line-length=120
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.11]
+        python-version: [3.9, 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
         python-version: [3.9, 3.11]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -19,15 +19,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
     - name: Build source distribution
-      run: python setup.py sdist
+      run: |
+        pip install build
+        python -m build
     - name: Lint with flake8
       run: |
-        pip install flake8
-        flake8 .  --statistics --show-source
+        flake8 . --statistics --show-source
     - name: Test with pytest
       run: |
-        pip install pytest
         pip install .
-        pytest
+        pytest --cov=prism --cov-report=term-missing

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,1 @@
-include versioneer.py
-include prism/_version.py
 include requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include prism/_version.py
+include requirements.txt

--- a/prism/commands/buckets_commands.py
+++ b/prism/commands/buckets_commands.py
@@ -205,18 +205,19 @@ def buckets_complete(ctx, isname, bucket):
     """
     p = ctx.obj["p"]
 
+    bucket_ref = bucket
     if isname:
-        buckets = p.buckets_get(bucket_name=bucket, verbosity="full")
+        buckets = p.buckets_get(bucket_name=bucket, type_="full")
 
         if buckets["total"] == 0:
             bucket = None
         else:
             bucket = buckets["data"][0]
     else:
-        bucket = p.buckets_list(bucket_id=bucket)
+        bucket = p.buckets_get(bucket_id=bucket)
 
     if bucket is None:
-        logger.error(f"Bucket {bucket} not found.")
+        logger.error(f"Bucket {bucket_ref} not found.")
         sys.exit(1)
 
     bucket_state = bucket["state"]["descriptor"]
@@ -284,10 +285,11 @@ def buckets_status(ctx, isname, bucket):
 
         bucket = buckets["data"][0]
     else:
-        bucket = p.buckets_get(bucket_id=bucket)
+        bucket_id = bucket
+        bucket = p.buckets_get(bucket_id=bucket_id)
 
     if bucket is None:
-        logger.error(f"Bucket {bucket} not found.")
+        logger.error(f"Bucket {bucket_id} not found.")
         sys.exit(1)
 
     logger.info(bucket["state"]["descriptor"])
@@ -299,4 +301,5 @@ def buckets_name(ctx):
     """
     Generate a bucket name to use for other bucket operations.
     """
-    click.echo(ctx.obj["p"].buckets_gen_name())
+    import prism
+    click.echo(prism.buckets_gen_name())

--- a/prism/commands/dataChanges_commands.py
+++ b/prism/commands/dataChanges_commands.py
@@ -140,7 +140,7 @@ def dataChanges_run(ctx, dct, fid, isname):
 
     if isname:
         # See if we have any matching data change task by name (with minor clean-up).
-        data_changes = p.dataChanges_get(name=dct.replace(" ", "_"))
+        data_changes = p.dataChanges_get(datachange_name=dct.replace(" ", "_"))
 
         if data_changes["total"] != 1:
             logger.error(f"Data change task not found: {dct}")
@@ -191,7 +191,7 @@ def dataChanges_activities(ctx, dct, activityid, status, isname):
 
     if isname:
         # See if we have any matching data change task.
-        data_changes = p.dataChanges_list(name=dct.replace(" ", "_"))
+        data_changes = p.dataChanges_get(datachange_name=dct.replace(" ", "_"))
 
         if data_changes["total"] != 1:
             logger.error(f"Data change task not found: {dct}")
@@ -271,7 +271,7 @@ def dataChanges_upload(ctx, isname, dct, file, wait, verbose):
     logger.debug(f"new file container ID: {filecontainer_id}")
 
     # Execute the DCT.
-    activity = p.dataChanges_activities_post(datachange_id=dct_id, fileContainer_id=filecontainer_id)
+    activity = p.dataChanges_activities_post(datachange_id=dct_id, filecontainer_id=filecontainer_id)
 
     if "errors" in activity:
         # Add the ID of the DCT for easy identification.

--- a/prism/commands/fileContainers_commands.py
+++ b/prism/commands/fileContainers_commands.py
@@ -62,7 +62,7 @@ def fileContainers_load(ctx, id, file):
     # Load the file and retrieve the ID - a new fID is
     # created if the command line ID was not specified.
     # Subsequent files are loaded into the same container (fID).
-    results = p.fileContainers_load(id=id, file=file)
+    results = p.fileContainers_load(filecontainer_id=id, file=file)
 
     # If the fID comes back blank, then something is not
     # working.  Note: any error messages have already

--- a/prism/commands/tables_commands.py
+++ b/prism/commands/tables_commands.py
@@ -66,10 +66,11 @@ def tables_get(ctx, isname, table, limit, offset, type_, compact, search):
     if not isname and table is not None:
         # When using an ID, the GET:/tables operation returns a simple
         # dictionary of the table definition.
-        table = p.tables_get(table_id=table, type_=type_)
+        table_id = table
+        table = p.tables_get(table_id=table_id, type_=type_)
 
         if table is None:
-            logger.error(f"Table ID {table} not found.")
+            logger.error(f"Table ID {table_id} not found.")
             sys.exit(1)
 
         if compact:
@@ -83,12 +84,11 @@ def tables_get(ctx, isname, table, limit, offset, type_, compact, search):
         tables = p.tables_get(table_name=table, limit=limit, offset=offset, type_=type_, search=search)
 
         if tables["total"] == 0:
-            logger.error(f"Table ID {table} not found.")
+            logger.error(f"Table name {table} not found.")
             return
 
         if compact:
-            for tab in tables["data"]:
-                tab = schema_compact(tab)
+            tables["data"] = [schema_compact(tab) for tab in tables["data"]]
 
         logger.info(json.dumps(tables, indent=2))
 
@@ -184,7 +184,7 @@ def tables_edit(ctx, file, truncate):
     # command line.
     schema = load_schema(file=file)
 
-    table = p.tables_put(schema, truncate=truncate)
+    table = p.tables_put(schema)
 
     if table is None:
         logger.error("Error updating table.")

--- a/prism/prism.py
+++ b/prism/prism.py
@@ -110,7 +110,7 @@ def schema_compact(schema):
         compact_schema["fields"] = [fld for fld in compact_schema["fields"] if not fld["name"].startswith("WPA_")]
 
         for ordinal in range(len(compact_schema["fields"])):
-            fld = schema["fields"][ordinal]
+            fld = compact_schema["fields"][ordinal]
             fld["ordinal"] = ordinal + 1
 
             if "fieldId" in fld:
@@ -516,7 +516,7 @@ class Prism:
         # parameters to perform a search.
         params = {
             "limit": limit if isinstance(limit, int) and limit <= 100 else 20,
-            "offset": offset if isinstance(limit, int) and offset >= 0 else 0,
+            "offset": offset if isinstance(offset, int) and offset >= 0 else 0,
             "type": output_type,
         }
 
@@ -1266,7 +1266,7 @@ class Prism:
             True if data change task is valid or False if the task does not
             exist or is not valid.
         """
-        dct = self.dataChanges_validate(id)
+        dct = self.dataChanges_validate(datachange_id)
 
         if dct is None:
             logger.error(f"data_change_id {datachange_id} not found!")
@@ -1668,13 +1668,13 @@ def load_schema(p=None, file=None, source_name=None, source_id=None):
             return None
 
         if source_id is not None:
-            schema = p.tables_list(id=source_id, type_="full")  # Exact match on WID - and get the fields (full)
+            schema = p.tables_get(table_id=source_id, type_="full")  # Exact match on WID - and get the fields (full)
 
             if schema is None:
                 logger.error(f"Invalid --sourceId {source_id} : table not found.")
                 return None
         else:
-            tables = p.tables_list(name=source_name, type_="full")  # Exact match on API Name
+            tables = p.tables_get(table_name=source_name, type_="full")  # Exact match on API Name
 
             if tables["total"] == 0:
                 logger.error(f"Invalid --sourceName {source_name} : table not found.")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 click>=6
 requests>=2.20.0,<3
 pytest
-black
+pytest-cov
 flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,4 @@
 
-# See the docstring in versioneer.py for instructions. Note that you must
-# re-run 'versioneer.py setup' after changing this section, and commit the
-# resulting files.
-
 [flake8]
 ignore = E203,W503
 max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="prism",
-    version="0.3.0",
+    version="0.3.1",
     description="Python API client to load data into Prism.",
     author="Curtis Hampton, Mark Waldron, Jacinta Corbett, Mark Greynolds",
     author_email="CurtLHampton@gmail.com",


### PR DESCRIPTION
- schema_compact: iterate compact_schema fields instead of original to avoid mutating input and misaligned indices after WPA_ field removal
- tables_get: fix offset validation to check isinstance(offset) not isinstance(limit)
- dataChanges_is_valid: pass datachange_id instead of Python built-in id()
- load_schema: replace non-existent tables_list() calls with tables_get()
- buckets_complete: replace non-existent buckets_list() with buckets_get(); fix verbosity= kwarg to type_=; preserve bucket ref for error message
- buckets_status: preserve bucket_id before overwriting for accurate error message
- buckets_name: call module-level prism.buckets_gen_name() instead of instance method
- tables_get command: preserve table ID before overwriting; fix error message label; fix compact loop to actually update tables["data"]
- tables_edit: remove non-existent truncate= kwarg from tables_put call
- dataChanges_run/activities: fix name= kwarg to datachange_name=; replace dataChanges_list() with dataChanges_get()
- dataChanges_upload: fix fileContainer_id= kwarg to filecontainer_id=
- fileContainers_load command: fix id= kwarg to filecontainer_id=